### PR TITLE
raise AttributeError if trying to access undefined variable

### DIFF
--- a/python_settings/__init__.py
+++ b/python_settings/__init__.py
@@ -110,7 +110,7 @@ class SetupSettings(object):
     def __getattr__(self, item):
         if self._wrapped is empty:
             self._setup(item)
-        get_attr = getattr(self._wrapped, item, object())
+        get_attr = getattr(self._wrapped, item, empty)
         if isinstance(get_attr, LazyProxy):
             try:
                 get_attr = get_attr()
@@ -121,6 +121,8 @@ class SetupSettings(object):
                     "LazySetting(MyCustomClass, [params])"
                     "Exception: %s - %s" % (type(ex), ex.__repr__())
                 )
+        if get_attr is empty:
+            raise AttributeError
         return get_attr
 
     def configure(self, default_settings, **options):

--- a/python_settings/__init__.py
+++ b/python_settings/__init__.py
@@ -82,9 +82,6 @@ class UserSettingsHolder:
     def __getattr__(self, name):
         return getattr(self.default_settings, name)
 
-    def __setattr__(self, name, value):
-        super().__setattr__(name, value)
-
 
 class SetupSettings(object):
 

--- a/python_settings/__init__.py
+++ b/python_settings/__init__.py
@@ -107,7 +107,7 @@ class SetupSettings(object):
     def __getattr__(self, item):
         if self._wrapped is empty:
             self._setup(item)
-        get_attr = getattr(self._wrapped, item, empty)
+        get_attr = getattr(self._wrapped, item)
         if isinstance(get_attr, LazyProxy):
             try:
                 get_attr = get_attr()
@@ -118,8 +118,6 @@ class SetupSettings(object):
                     "LazySetting(MyCustomClass, [params])"
                     "Exception: %s - %s" % (type(ex), ex.__repr__())
                 )
-        if get_attr is empty:
-            raise AttributeError
         return get_attr
 
     def configure(self, default_settings, **options):

--- a/python_settings/tests/test_python_settings.py
+++ b/python_settings/tests/test_python_settings.py
@@ -37,6 +37,14 @@ class TestPythonSettings(unittest.TestCase):
         self.assertEqual(settings.DEFAULT_VALUE, DEFAULT_VALUE)
         self.assertEqual(settings.DEFAULT_CONSTANT, DEFAULT_CONSTANT)
 
+    def test_attribute_error(self):
+        from python_settings import settings
+        # make sure AttributeError is thrown for missing Attribute
+        with self.assertRaises(AttributeError) as a:
+            print(settings.NOT_A_SETTING)
+        # make sure we get the default value out of getattr
+        self.assertEqual(getattr(settings, 'NOTHING', 'default'), 'default')
+
     def test_config_environment(self):
         from python_settings.tests.settings.base_settings import URL_CONFIG
         from python_settings import settings


### PR DESCRIPTION
so that `getattr(settings, 'VARIABLE', default)` behaves as it should – returning the default rather than the empty object