### PR TITLE
Add exception inheritance on import settings module. Add initial error message.

### DIFF
--- a/python_settings/__init__.py
+++ b/python_settings/__init__.py
@@ -60,9 +60,9 @@ class Settings(BaseSettings):
             mod = importlib.import_module(
                 self.SETTINGS_MODULE)
         except ImportError as ie:
-            raise ImproperlyConfigured(f"Cannot import SETTINGS_MODULE: {ie}") from ie
+            raise ImproperlyConfigured("Cannot import SETTINGS_MODULE: {}".format(ie))
         except Exception as e:
-            raise ImproperlyConfigured(f"Error trying to import your settings module: {e}") from e
+            raise ImproperlyConfigured("Error trying to import your settings module: {}".format(e))
         for setting in dir(mod):
             if setting.isupper():
                 setting_value = getattr(mod, setting)

--- a/python_settings/__init__.py
+++ b/python_settings/__init__.py
@@ -59,10 +59,10 @@ class Settings(BaseSettings):
             self.SETTINGS_MODULE = settings_module
             mod = importlib.import_module(
                 self.SETTINGS_MODULE)
-        except ImportError:
-            raise ImproperlyConfigured("Cannot import SETTINGS_MODULE")
-        except Exception:
-            raise ImproperlyConfigured("Error trying to import your settings module")
+        except ImportError as ie:
+            raise ImproperlyConfigured(f"Cannot import SETTINGS_MODULE: {ie}") from ie
+        except Exception as e:
+            raise ImproperlyConfigured(f"Error trying to import your settings module: {e}") from e
         for setting in dir(mod):
             if setting.isupper():
                 setting_value = getattr(mod, setting)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='python-settings',
-    version='0.2.2',
+    version='0.2.3',
     packages=setuptools.find_packages(),
     url='https://github.com/charlsagente/python-settings',
     license='MIT',


### PR DESCRIPTION
Hi! 
I like your project and use it in all my non-django projects. Thank you for it!

From time to time I'm facing with issue when settings file contains errors. For example I'm using python-decouple and when I don't specify default value for env and it wasn't passed properly, then I get ImproperlyConfigured exception, but it's not so informative. I suggest to add a bit details which would make it easier to debug and fix.
It would be great to have this changes in a new version.
Here is screenshots with logs to see the difference:

Before: 
![image](https://github.com/user-attachments/assets/ca87c622-6548-4b0a-be99-dfb7c997bd4c)

---
After:
![image](https://github.com/user-attachments/assets/62a6e793-f492-4772-9d8f-53a4b7537fb0)
