### PR TITLE
Add python 3.12 and 3.13 to testing environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ workflows:
       - test-3.9
       - test-3.10
       - test-3.11
+      - test-3.12
+      - test-3.13
 jobs:
   test-3.7: &test-template
     docker:
@@ -56,3 +58,13 @@ jobs:
     <<: *test-template
     docker:
       - image: cimg/python:3.11
+
+  test-3.12:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.12
+
+  test-3.13:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.13


### PR DESCRIPTION
I suggest to add new versions to the list of testing environments. Tested it with local validator:
```
$ circleci config validate
Config file at .circleci/config.yml is valid.
```